### PR TITLE
Add page w/ good & bad examples of commit messages

### DIFF
--- a/commitMessagesPage.html
+++ b/commitMessagesPage.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commit Messages: the Good, the Bad, and the Ugly</title>
+  </head>
+  <body>
+    <h1>Commit Messages: The Good, the Bad, and the Ugly</h1>
+    <h2>Or... how I stopped worrying and learned to love the microcopy</h2>
+    <h4>The Good:</h4>
+    <p>Add page w/ good & bad examples of commit messages</p>
+    <h4>The Bad:</h4>
+    <p>commit messages</p>
+    <h4>The Ugly:</h4>
+    <p>
+      In this commit I have decided to add the code for a page to add examples
+      of commit messages that people can learn from so they know what is
+      considered good practice and not so good practice
+    </p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,5 +12,6 @@
       src="https://camo.githubusercontent.com/c0cd7991caeb2b8b037fd2088dabc216b4d50f3f/68747470733a2f2f66656174757265666c6167732e696f2f77702d636f6e74656e742f75706c6f6164732f323031382f30332f666561747572656272616e6368696e67776974686f75742e6a7067"
       alt="git branching without flags"
     />
+    <a href="/commitMessagesPage.html">
   </body>
 </html>


### PR DESCRIPTION
This pull request adds:

A new page with examples of commit messages that could be considered good / bad, so that users can learn how to write commit messages. 

Future improvements:
* Add styling.
* Add more in-depth explanation of what makes a good commit message.